### PR TITLE
Share webpack config subset between dev and prod

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -1,0 +1,34 @@
+const paths = require('../config/paths');
+
+module.exports = {
+  output: {
+    // The build folder.
+    path: paths.dist
+  },
+  resolveLoader: {
+    // Look for loaders in own ./node_modules
+    root: paths.ownModules,
+    moduleTemplates: [ '*-loader' ]
+  },
+  resolve: {
+    modulesDirectories: [ 'node_modules' ],
+    extensions: [ '', '.js', '.elm' ]
+  },
+  module: {
+    noParse: /\.elm$/,
+    loaders: [
+      {
+        test: /\.css$/,
+        loader: 'style!css'
+      },
+      {
+        test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
+        exclude: /\/favicon.ico$/,
+        loader: 'file',
+        query: {
+          name: 'static/media/[name].[hash:8].[ext]'
+        }
+      }
+    ]
+  }
+};

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,13 +1,15 @@
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const paths = require('../config/paths');
+const merge = require('webpack-merge');
 
-module.exports = {
+const paths = require('../config/paths');
+const baseConfig = require('./webpack.config.base');
+
+module.exports = merge(baseConfig, {
 
   devtool: 'eval',
 
   entry: [
-
     // WebpackDevServer client.
     require.resolve('webpack-dev-server/client') + '?/',
 
@@ -17,46 +19,19 @@ module.exports = {
     paths.entry
   ],
   output: {
-
     pathinfo: true,
-
-    // The build folder.
-    path: paths.dist,
 
     // Generated JS files.
     filename: 'dist/js/bundle.js',
 
     publicPath: '/'
   },
-  resolveLoader: {
-
-    // Look for loadres in own node_modules
-    root: paths.ownModules,
-    moduleTemplates: [ '*-loader' ]
-  },
-  resolve: {
-    modulesDirectories: [ 'node_modules' ],
-    extensions: [ '', '.js', '.elm' ]
-  },
   module: {
-    noParse: /\.elm$/,
     loaders: [
       {
         test: /\.elm$/,
         exclude: [ /elm-stuff/, /node_modules/ ],
         loader: 'elm-hot!elm-webpack?verbose=true&warn=true&pathToMake=' + paths.elmMake
-      },
-      {
-        test: /\.css$/,
-        loader: 'style!css'
-      },
-      {
-        test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
-        exclude: /\/favicon.ico$/,
-        loader: 'file',
-        query: {
-          name: 'static/media/[name].[hash:8].[ext]'
-        }
       }
     ]
   },
@@ -68,4 +43,4 @@ module.exports = {
     }),
     new webpack.HotModuleReplacementPlugin()
   ]
-};
+});

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,57 +1,29 @@
 const webpack = require('webpack');
-const paths = require('../config/paths');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const merge = require('webpack-merge');
+
+const paths = require('../config/paths');
+const baseConfig = require('./webpack.config.base');
 
 const root = process.cwd();
 
-module.exports = {
+module.exports = merge(baseConfig, {
   bail: true,
   entry: [
     paths.entry
   ],
   output: {
 
-    // The build folder.
-    path: paths.dist,
-
     // Generated JS files.
     filename: 'js/[name].[chunkhash:8].js'
   },
-  resolveLoader: {
-
-    // Look for loaders in own ./node_modules
-    root: paths.ownModules,
-    moduleTemplates: [ '*-loader' ]
-  },
-  resolve: {
-    modulesDirectories: [ 'node_modules' ],
-    extensions: [ '', '.js', '.elm' ]
-  },
   module: {
-    noParse: /\.elm$/,
     loaders: [
       {
         test: /\.elm$/,
         exclude: [ /elm-stuff/, /node_modules/ ],
-
-        // Use the local installation of elm-make
-        loader: 'elm-webpack',
-        query: {
-          pathToMake: paths.elmMake
-        }
-      },
-      {
-        test: /\.css$/,
-        loader: 'style!css'
-      },
-      {
-        test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
-        exclude: /\/favicon.ico$/,
-        loader: 'file',
-        query: {
-          name: 'static/media/[name].[hash:8].[ext]'
-        }
+        loader: 'elm-webpack?pathToMake=' + paths.elmMake
       }
     ]
   },
@@ -92,4 +64,4 @@ module.exports = {
       }
     })
   ]
-};
+});

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "prompt": "1.0.0",
     "style-loader": "0.13.1",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "1.15.1"
+    "webpack-dev-server": "1.15.1",
+    "webpack-merge": "^0.14.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Introduces `webpack.config.base.js` in `config/` which contains the shared
configuration between dev and prod.

Configs are then merged using webpack-merge in dev & prod to avoid
duplication.

Inspired by [elm-webpack-starter](https://github.com/moarwick/elm-webpack-starter/blob/master/webpack.config.js#L14-L15)