### PR TITLE
Add Autoprefixer to CSS output from Webpack

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,3 +1,4 @@
+const autoprefixer = require('autoprefixer');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const paths = require('../config/paths');
@@ -48,7 +49,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: 'style!css'
+        loader: 'style!css!postcss'
       },
       {
         test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
@@ -59,6 +60,18 @@ module.exports = {
         }
       }
     ]
+  },
+  postcss: function() {
+    return [
+      autoprefixer({
+        browsers: [
+          '>1%',
+          'last 4 versions',
+          'Firefox ESR',
+          'not ie < 9'
+        ]
+      })
+    ];
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,6 +1,8 @@
+const autoprefixer = require('autoprefixer');
 const webpack = require('webpack');
 const paths = require('../config/paths');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 const root = process.cwd();
@@ -43,7 +45,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: 'style!css'
+        loader: ExtractTextPlugin.extract('style', 'css?-autoprefixer!postcss')
       },
       {
         test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
@@ -54,6 +56,18 @@ module.exports = {
         }
       }
     ]
+  },
+  postcss: function() {
+    return [
+      autoprefixer({
+        browsers: [
+          '>1%',
+          'last 4 versions',
+          'Firefox ESR',
+          'not ie < 9'
+        ]
+      })
+    ];
   },
   plugins: [
 
@@ -90,6 +104,8 @@ module.exports = {
         minifyCSS: true,
         minifyURLs: true
       }
-    })
+    }),
+
+    new ExtractTextPlugin('css/[name].[contenthash:8].css')
   ]
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     }
   },
   "dependencies": {
+    "autoprefixer": "^6.5.0",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
     "clean-webpack-plugin": "^0.1.10",
@@ -50,6 +51,7 @@
     "elm-hot-loader": "^0.3.3",
     "elm-webpack-loader": "^3.0.5",
     "extend": "^3.0.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "fs-extra": "^0.30.0",
     "html-webpack-plugin": "^2.22.0",
@@ -58,6 +60,7 @@
     "opn": "^4.0.2",
     "path-exists": "^3.0.0",
     "prompt": "1.0.0",
+    "postcss-loader": "^0.13.0",
     "style-loader": "0.13.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "1.15.1"


### PR DESCRIPTION
Vendor prefix the css as well as extract it into it's own stylesheet on
build. Taken from create-react-app webpack config.