### PR TITLE
Add getting started instructions to create script.

### DIFF
--- a/scripts/create.js
+++ b/scripts/create.js
@@ -53,4 +53,25 @@ function createElmApp (name) {
   }
 
   console.log(chalk.green('\nProject is successfully created in `' + root + '`.'));
+  console.log();
+  console.log('Inside that directory, you can run several commands:');
+  console.log();
+  console.log(chalk.cyan('  elm-app start'));
+  console.log('    Starts the development server.');
+  console.log();
+  console.log(chalk.cyan('  elm-app build'));
+  console.log('    Bundles the app into static files for production.');
+  console.log();
+  console.log(chalk.cyan('  elm-app test'));
+  console.log('    Starts the test runner.');
+  console.log();
+  console.log(chalk.cyan('  elm-app eject'));
+  console.log('    Removes this tool and copies build dependencies, configuration files');
+  console.log('    and scripts into the app directory. If you do this, you can’t go back!');
+  console.log();
+  console.log('We suggest that you begin by typing:');
+  console.log();
+  console.log(chalk.cyan('  cd'), name);
+  console.log('  ' + chalk.cyan('elm-app start'));
+  console.log();
 }


### PR DESCRIPTION
Hi!

I've used this tool a couple times but each time I did I ended up having to go back to the GitHub repository in order to find the command `elm-app start`.  I thought it would be nice to have parity with `create-react-app`'s initialization message.

Let me know if some of the copy isn't exactly right, for instance, "Removes this tool and copies build dependencies, configuration files and scripts into the app directory" might not be exactly what `elm-app eject` does.

Also, I didn't see any issues for this so it might not be a big enough deal to warrant a change. Don't hesitate to close this PR if you're not interested :)

Cheers!

EDIT:
Here is a screenshot so you don't have to rummage around in a local build to check it out:
![screen shot 2016-11-09 at 10 25 52 pm](https://cloud.githubusercontent.com/assets/3782604/20164699/324d7d0c-a6cc-11e6-9f26-5bad997cfff0.png)
