### PR TITLE
Add debug flag to be used with elm 0.18 debugger

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -45,7 +45,7 @@ module.exports = {
       {
         test: /\.elm$/,
         exclude: [ /elm-stuff/, /node_modules/ ],
-        loader: 'elm-hot!elm-webpack?verbose=true&warn=true&pathToMake=' + paths.elmMake
+        loader: 'elm-hot!elm-webpack?verbose=true&warn=true&debug=true&pathToMake=' + paths.elmMake
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
I tried to start app with debug flag after updating to elm 0.18 but there was a missing flag in webpack dev configuration. This PR adds it