### PR TITLE
Add few eslint rules to validate bracket spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,9 @@
       "error",
       "always"
     ],
-    "no-console": 0
+    "no-console": 0,
+    "array-bracket-spacing": [2, "always"],
+    "computed-property-spacing": [2, "always"]
   },
   "env": {
     "node": true,

--- a/tests/create-elm-app.spec.js
+++ b/tests/create-elm-app.spec.js
@@ -17,7 +17,7 @@ describe('Create Elm application with `create-elm-app` command', function () {
   });
 
   it('`create-elm-app ' + testAppName + '` should succeed', function () {
-    const status = spawn.sync('node', [createElmAppCmd, testAppName ]).status;
+    const status = spawn.sync('node', [ createElmAppCmd, testAppName ]).status;
     expect(status).to.be.equal(0);
   }).timeout(60 * 1000);
 

--- a/tests/elm-app.build.spec.js
+++ b/tests/elm-app.build.spec.js
@@ -30,7 +30,7 @@ describe('Building Elm application with `elm-app build`', function () {
   });
 
   it('`elm-app build` should succeed in `' + testAppName + '`', function () {
-    var result = spawn.sync('node', [elmAppCmd, 'build' ]);
+    var result = spawn.sync('node', [ elmAppCmd, 'build' ]);
     var outputString = result.output.map(function (out) {
       return (out !== null) ? out.toString() : '';
     }).join('');


### PR DESCRIPTION
Due to fixes in #62  like
https://github.com/halfzebra/create-elm-app/pull/62/commits/3940a1fa212eb781db7ab25effe833fcc8f3f49f#diff-26656f8f2b440480d38c7ded4bafa17cR20
https://github.com/halfzebra/create-elm-app/pull/62/commits/3940a1fa212eb781db7ab25effe833fcc8f3f49f#diff-26656f8f2b440480d38c7ded4bafa17cR37

have added `array-bracket-spacing` and `computed-property-spacing` rules.

P.S. I think it's uncommon code style.