### PR TITLE
Update Elm Webpack Loader to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "elm": "^0.18.0",
     "elm-hot-loader": "0.5.3",
     "elm-test": "0.18.2",
-    "elm-webpack-loader": "3.1.0",
+    "elm-webpack-loader": "4.0.0",
     "extend": "3.0.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",


### PR DESCRIPTION
Just noticed that this shouldn't be merged yet because of https://github.com/rtfeldman/elm-webpack-loader/pull/80. That PR to fix hot loading has been merged but is not released yet - but maybe we can just leave this PR open and I'll update it when elm-webpack-loader is released? Unless you feel comfortable depending on a git commit in a `package.json` which I'm not sure about.

I also think this should make Elm Webpack report warnings correctly so once this is done I can take a stab at #15 again.