### PR TITLE
fix(): list glob in the dependencies explicitly so installation will work for npm < 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "fs-extra": "1.0.0",
+    "glob": "^7.1.1",
     "html-webpack-plugin": "2.24.1",
     "http-proxy-middleware": "^0.17.3",
     "minimist": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,7 +1657,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:


### PR DESCRIPTION
right now installation do not work for npm < 3.0 because it do not install dependencies in a flat

way, this change fix this issue

https://github.com/halfzebra/create-elm-app/issues/91