### PR TITLE
enabled history api fallback on the web pack dev server

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -156,7 +156,8 @@ const devServer = new WebpackDevServer(compiler, {
   hot: true,
   inline: true,
   publicPath: '/',
-  quiet: true
+  quiet: true,
+  historyApiFallback: true
 });
 
 addMiddleware(devServer);


### PR DESCRIPTION
This is one tweak that makes apps with client side routing (common for an elm app) work when F5 is pressed. A tiny config change which seems to have little downside. Seems a shame to have to eject just to add this. 

Understand if you feel like this is something that should not be on by default. 