### PR TITLE
fix(cli): Fix crash when installed via yarn

### DIFF
--- a/bin/create-elm-app-cli.js
+++ b/bin/create-elm-app-cli.js
@@ -4,7 +4,7 @@ const path = require('path');
 const spawn = require('cross-spawn');
 const argv = require('minimist')(process.argv.slice(2));
 const version = require('../package.json').version;
-const elmPlatformVersion = require('../node_modules/elm/package.json').version;
+const elmPlatformVersion = require('elm/package.json').version;
 const commands = argv._;
 
 if (commands.length === 0) {


### PR DESCRIPTION
`create-elm-app` crashed out-of-the-box after installing with `yarn global add create-elm-app`, at least on yarn 0.19.1. This was due to the fact that yarn had installed the `elm` package alongside `create-elm-app` rather than in the expected `create-elm-app/node_modules`.

Fixes #90