### PR TITLE
fix(cli): Fix crash in elm-app installed with yarn

### DIFF
--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -6,7 +6,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const executablePaths = require('elm/platform').executablePaths;
 
 const version = require('../package.json').version;
-const elmPlatformVersion = require('../node_modules/elm/package.json').version;
+const elmPlatformVersion = require('elm/package.json').version;
 const paths = require('../config/paths');
 
 


### PR DESCRIPTION
This is the same bug as was with the create-elm-app cli. `elm-app` crashes if it's been installed with yarn.