### PR TITLE
fix(elm test) (#98) Fixed an elm type error in tests.

### DIFF
--- a/template/tests/Tests.elm
+++ b/template/tests/Tests.elm
@@ -11,7 +11,7 @@ all =
     describe "A Test Suite"
         [ test "App.model.message should be set properly" <|
             \() ->
-                Expect.equal (Tuple.first App.init |> .message) "Your Elm App is working!"
+                Expect.equal (Tuple.first (App.init  "../src/logo.svg") |> .message) "Your Elm App is working!"
         , test "Addition" <|
             \() ->
                 Expect.equal (3 + 7) 10


### PR DESCRIPTION
App.init takes the logo path, which should also be provided in the tests, see:
https://github.com/halfzebra/create-elm-app/issues/98