### PR TITLE
Add elm-app commands as npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Create Elm apps with no build configuration.
 npm install create-elm-app -g
 create-elm-app my-app
 cd my-app/
-elm-app start
+npm start
 ```
 
-Create a production build with `elm-app build`
+Create a production build with `npm run build`
 
 ## Getting Started
 
@@ -64,7 +64,7 @@ my-app/
 
 You are ready to employ the full power of Create Elm App!
 
-### `elm-app start`
+### `npm start`
 Run the app in development mode.
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
@@ -73,7 +73,7 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.
 You will see the build errors and lint warnings in the console and the browser window.
 
-### `elm-app build`
+### `npm run build`
 Builds the app for production to the `build` folder.
 It bundles Elm app and optimizes the build for the best performance.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "create-elm-app": "./bin/create-elm-app-cli.js"
   },
   "scripts": {
+    "start": "elm-app start",
+    "build": "elm-app build",
+    "eject": "elm-app eject",
+    "create": "elm-app create",
     "commit": "git-cz",
     "precommit": "standard --verbose | snazzy",
     "test": "npm run -s test:cli && npm run -s test:functional",


### PR DESCRIPTION
Hi @halfzebra 

I open this PR to facilitate to call elm-app from outside. (It's similar what create-react-app does).
I change the README only, If it does make sense I would change the CLI messages too.

