### PR TITLE
Template: Tests.elm: Expectation argument order

### DIFF
--- a/template/tests/Tests.elm
+++ b/template/tests/Tests.elm
@@ -11,10 +11,11 @@ all =
     describe "A Test Suite"
         [ test "App.model.message should be set properly" <|
             \() ->
-                Expect.equal (Tuple.first (App.init  "../src/logo.svg") |> .message) "Your Elm App is working!"
+                (Tuple.first (App.init  "../src/logo.svg") |> .message)
+                    |> Expect.equal "Your Elm App is working!"
         , test "Addition" <|
             \() ->
-                Expect.equal (3 + 7) 10
+                Expect.equal 10 (3 + 7)
         , test "String.left" <|
             \() ->
                 Expect.equal "a" (String.left 1 "abcdefg")


### PR DESCRIPTION
The expected value should come first and the actual value second.