### PR TITLE
Integrate elm-css

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -50,7 +50,7 @@ module.exports = {
   },
 
   module: {
-    noParse: /\.elm$/,
+    noParse: /^((?!Stylesheet).)*\.elm.*$/,
 
     rules: [
       {
@@ -68,7 +68,7 @@ module.exports = {
 
       {
         test: /\.elm$/,
-        exclude: [/elm-stuff/, /node_modules/],
+        exclude: [/elm-stuff/, /node_modules/, /Stylesheets\.elm$/],
         use: [
           {
             loader: require.resolve('elm-hot-loader')
@@ -94,6 +94,22 @@ module.exports = {
               forceWatch: true
             }
           }
+        ]
+      },
+
+      {
+        test: /Stylesheets\.elm$/,
+        use: [
+          'style-loader',
+          {
+            loader: require.resolve('string-replace-loader'),
+            query: {
+              search: '%PUBLIC_URL%',
+              replace: publicUrl
+            }
+          },
+          'css-loader',
+          'elm-css-webpack-loader',
         ]
       },
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "css-loader": "^0.28.0",
     "dotenv": "^4.0.0",
     "elm": "^0.18.0",
+    "elm-css-webpack-loader": "^3.1.0",
     "elm-hot-loader": "0.5.4",
     "elm-test": "^0.18.4",
     "elm-webpack-loader": "^4.3.0",

--- a/template/README.md
+++ b/template/README.md
@@ -238,6 +238,108 @@ The `public` folder is useful as a workaround for a number of less common cases:
 
 Note that if you add a `<script>` that declares global variables, you also need to read the next section on using them.
 
+## Integrate elm-css
+
+### Step 1: Install required depedencies
+
+```sh
+elm-app package install rtfeldman/elm-css
+elm-app package install elm-css-helpers
+```
+
+### Step 2: Create the stylesheet file
+
+Create an Elm file at `src/Stylesheets.elm` (The name of this file cannot be changed).
+
+```elm
+port module Stylesheets exposing (main, CssClasses(..), CssIds(..), helpers)
+
+import Css exposing (..)
+import Css.Elements exposing (body, li)
+import Css.Namespace exposing (namespace)
+import Css.File exposing (..)
+import Html.CssHelpers exposing (withNamespace)
+
+
+port files : CssFileStructure -> Cmd msg
+
+
+cssFiles : CssFileStructure
+cssFiles =
+    toFileStructure [ ( "style.css", Css.File.compile [ css ] ) ]
+
+
+main : CssCompilerProgram
+main =
+    Css.File.compiler files cssFiles
+
+
+type CssClasses
+    = NavBar
+
+
+type CssIds
+    = Page
+
+
+appNamespace =
+    "App"
+
+
+helpers =
+    withNamespace appNamespace
+
+
+css =
+    (stylesheet << namespace appNamespace)
+    [ body
+        [ overflowX auto
+        , minWidth (px 1280)
+        ]
+    , id Page
+        [ backgroundColor (rgb 200 128 64)
+        , color (hex "CCFFFF")
+        , width (pct 100)
+        , height (pct 100)
+        , boxSizing borderBox
+        , padding (px 8)
+        , margin zero
+        ]
+    , class NavBar
+        [ margin zero
+        , padding zero
+        , children
+            [ li
+                [ (display inlineBlock) |> important
+                , color primaryAccentColor
+                ]
+            ]
+        ]
+    ]
+
+
+primaryAccentColor =
+    hex "ccffaa"
+```
+
+### Step 3: Import the stylesheet
+
+Add the following line to your index.js:
+
+
+```js
+import './Stylesheets.elm'
+```
+
+### Testing the stylesheet
+
+To inspect the generated CSS file, just run
+
+```sh
+elm-css src/Stylesheets.elm
+```
+
+This will generate a file called `style.css`
 
 ## Setting up API Proxy
 To forward the API ( REST ) calls to backend server, add a proxy to the `elm-package.json` in the top level json object.

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,7 +147,7 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
-ansi-styles@^2.2.1:
+ansi-styles@^2.1.0, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
@@ -1136,6 +1136,16 @@ chai@^4.0.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
+chalk@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.1.tgz#509afb67066e7499f7eb3535c77445772ae2d019"
+  dependencies:
+    ansi-styles "^2.1.0"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1484,6 +1494,20 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-spawn-async@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
+
+cross-spawn@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-2.1.0.tgz#9bc27f40423e98a445efe9269983e4f4055cde3a"
+  dependencies:
+    cross-spawn-async "^2.0.0"
+    spawn-sync "1.0.13"
 
 cross-spawn@4.0.0:
   version "4.0.0"
@@ -1959,6 +1983,25 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+elm-css-webpack-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/elm-css-webpack-loader/-/elm-css-webpack-loader-3.1.0.tgz#cb8fbbaa529015aeb69e03e57487da1a241066ba"
+  dependencies:
+    elm-css "^0.6.0"
+    loader-utils "^1.0.3"
+    lodash "^4.17.4"
+    node-elm-compiler "^4.3.0"
+    temp "^0.8.3"
+
+elm-css@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/elm-css/-/elm-css-0.6.1.tgz#a533c9856acbe9470e67c98f5e45d2755159850c"
+  dependencies:
+    chalk "1.1.1"
+    commander "2.9.0"
+    node-elm-compiler "2.3.2"
+    tmp "0.0.28"
 
 elm-hot-loader@0.5.4:
   version "0.5.4"
@@ -3509,7 +3552,7 @@ loader-utils@^0.2.12, loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -3681,6 +3724,10 @@ lodash@3.0.x:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.0.1.tgz#14d49028a38bc740241d11e2ecd57ec06d73c19a"
 
+lodash@3.10.1, lodash@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@4.13.1:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
@@ -3692,10 +3739,6 @@ lodash@4.14.2:
 lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
-
-lodash@^3.6.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -3726,7 +3769,7 @@ lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
@@ -3993,7 +4036,15 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-elm-compiler@4.3.2, node-elm-compiler@^4.2.1:
+node-elm-compiler@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-2.3.2.tgz#38fa4221a0d26185434aa6f71edd90e432ef8f15"
+  dependencies:
+    cross-spawn "2.1.0"
+    lodash "3.10.1"
+    temp "^0.8.3"
+
+node-elm-compiler@4.3.2, node-elm-compiler@^4.2.1, node-elm-compiler@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-4.3.2.tgz#ff8deccb19c29c037af964f37e7c49b6efce1c5e"
   dependencies:
@@ -5615,6 +5666,13 @@ source-map@0.5.6, source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+spawn-sync@1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.13.tgz#904091b9ad48a0f3afb0e84752154c01e82fd8d8"
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
+
 spawn-sync@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
@@ -5918,6 +5976,12 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@0.0.28:
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 tmp@^0.0.29:
   version "0.0.29"
@@ -6302,7 +6366,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.12, which@^1.2.8, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
Tracked in #134 

I tried to implement this as we discussed.

The stylesheet module is called `Stylesheets`, not `Stylesheet`, because I coundn't find a way to make elm-css-webpack-loader load a different module. In all the elm-css examples I saw, the plural version of the name was used, so this might not be so bad.

I included the `noParse` workaround you proposed.

There is an example `Stylesheets` module which is included in `index.js` and elm-css dependencies are added to elm-package.json.