### PR TITLE
Fix folder structure in the template docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ my-app/
     favicon.ico
     index.html
   src/
-    App.elm
+    Main.elm
     index.js
     main.css
   tests/

--- a/template/README.md
+++ b/template/README.md
@@ -69,7 +69,7 @@ my-app/
     favicon.ico
     index.html
   src/
-    App.elm
+    Main.elm
     index.js
     main.css
   tests/

--- a/template/README.md
+++ b/template/README.md
@@ -65,10 +65,11 @@ my-app/
   .gitignore
   README.md
   elm-package.json
-  src/
-    App.elm
+  public/
     favicon.ico
     index.html
+  src/
+    App.elm
     index.js
     main.css
   tests/
@@ -78,8 +79,8 @@ my-app/
 ```
 For the project to build, these files must exist with exact filenames:
 
-- `src/index.html` is the page template;
-- `src/favicon.ico` is the icon you see in the browser tab;
+- `public/index.html` is the page template;
+- `public/favicon.ico` is the icon you see in the browser tab;
 - `src/index.js` is the JavaScript entry point.
 
 You can delete or rename the other files.


### PR DESCRIPTION
In #135 the folder structure changed and the docs on README.md did too,
but not the ones on the template README.

This commit fixes the folder structure section.