### PR TITLE
Fix ELM_DEBUGGER parsing

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -105,7 +105,9 @@ module.exports = {
             options: {
               verbose: true,
               warn: true,
-              debug: !!process.env.ELM_DEBUGGER,
+              // If ELM_DEBUGGER was set to "false", disable it. Otherwise
+              // for invalid values, "true" and as a default, enable it
+              debug: process.env.ELM_DEBUGGER === 'false' ? false : true,
               pathToMake: paths.elmMake,
               forceWatch: true
             }


### PR DESCRIPTION
`!!process.env.ELM_DEBUGGER` is default to `false`, and any string will parse to `true`, even `"false"`, contradicting the documented behavior.

This PR fixes how the string is parsed from the command line to default to `true`, and make `"false"` disable the debugger.

**Edited for correctness**

---
## Original PR text

### docs: Update how to enable the debugger

With the last version it seems like the debugger is turned off by
default and it can be enabled with the ELM_DEBUGGER env variable.

Not sure if that was the intention but it is the behavior, so this updates the docs. \

Maybe the default on `elm-app start` should actually default to debugger true. Feel free to close if so.