### PR TITLE
docs: Change refs to React and npm with Elm and elm-app

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -231,7 +231,7 @@ Inside `index.html`, you can use it like this:
 
 Only files inside the `public` folder will be accessible by `%PUBLIC_URL%` prefix. If you need to use a file from `src` or `node_modules`, you’ll have to copy it there to explicitly specify your intention to make this file a part of the build.
 
-When you run `npm run build`, Create React App will substitute `%PUBLIC_URL%` with a correct absolute path so your project works even if you use client-side routing or host it at a non-root URL.
+When you run `elm-app build`, Create Elm App will substitute `%PUBLIC_URL%` with a correct absolute path so your project works even if you use client-side routing or host it at a non-root URL.
 
 In Elm code, you can use `%PUBLIC_URL%` for similar purposes:
 


### PR DESCRIPTION
*Create React App* and `npm run build` were mentioned. This swaps them for *Create Elm App* and `elm-app`.

There is also some mentions of react-scripts and *Create react app* in the github pages deploy section of the docs. Not sure how valid that section is tho, so I didn't touch them.