### PR TITLE
Add .env file path to paths config

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -43,6 +43,7 @@ module.exports = {
   appHtml: resolveApp('./public/index.html'),
   appIndexJs: resolveApp('./src/index.js'),
   appSrc: resolveApp('./src'),
+  dotenv: resolveApp('./.env'),
   entry: resolveApp('./src/index.js'),
   appBuild: resolveApp('./build'),
   elmPackageJson: resolveApp('./elm-package.json'),


### PR DESCRIPTION
Defines the base path of `.env` files in `config/paths.js`. This definition is referenced by `config/env.js`, which sets up the environment variables before starting or building with create-elm-app.