### PR TITLE
Tests.elm: Remove 'import String'

### DIFF
--- a/template/tests/Tests.elm
+++ b/template/tests/Tests.elm
@@ -2,7 +2,6 @@ module Tests exposing (..)
 
 import Test exposing (..)
 import Expect
-import String
 
 
 -- Check out http://package.elm-lang.org/packages/elm-community/elm-test/latest to learn more about testing in Elm!


### PR DESCRIPTION
This import is already in the Elm prelude.