### PR TITLE
test: Add utility scripts test

### DIFF
--- a/tests/elm-app.eject.spec.js
+++ b/tests/elm-app.eject.spec.js
@@ -83,4 +83,17 @@ describe('Ejecting Elm application. (Please wait...)', () => {
     expect(status, 'to be', 0);
     expect(outputString, 'to contain', 'Compiled successfully');
   }).timeout(5 * 60 * 1000);
+
+  it('Ejected application should have utility scripts', () => {
+    expect(
+      fs.existsSync(path.join(testAppDir, './scripts/utils/formatElmCompilerErrors.js')),
+      'to be',
+      true
+    );
+    expect(
+      fs.existsSync(path.join(testAppDir, './scripts/utils/webpackHotDevClient.js')),
+      'to be',
+      true
+    );
+  });
 });


### PR DESCRIPTION
This PR add tests that checks that `scripts/utils/formatElmCompilerErrors.js` and `scripts/utils/webpackHotDevClient.js` exists.