### PR TITLE
refactor(Create-elm-app template): Changed body font size because it …

### DIFF
--- a/template/src/Main.elm
+++ b/template/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Html exposing (Html, text, div, img)
+import Html exposing (Html, text, div, h1, img)
 import Html.Attributes exposing (src)
 
 
@@ -37,7 +37,7 @@ view : Model -> Html Msg
 view model =
     div []
         [ img [ src "/logo.svg" ] []
-        , div [] [ text "Your Elm App is working!" ]
+        , h1 [] [ text "Your Elm App is working!" ]
         ]
 
 

--- a/template/src/main.css
+++ b/template/src/main.css
@@ -1,9 +1,12 @@
 body {
   font-family: 'Source Sans Pro', 'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif;
-  font-size: 30px;
   margin: 0;
   text-align: center;
   color: #293c4b;
+}
+
+h1 {
+  font-size: 30px;
 }
 
 img {


### PR DESCRIPTION
Changed body font size because it also affects the Elm debugger overlay and it looks really weird when I start newly created elm-app. Now the font-size is applied to h1 and text is also changed from div to h1.

Before:
![snimek obrazovky 2017-10-28 v 16 09 22](https://user-images.githubusercontent.com/1932160/32135238-2bc6c97a-bbfc-11e7-931f-f0febbdb1d5f.png)

Now:
![snimek obrazovky 2017-10-28 v 16 08 29](https://user-images.githubusercontent.com/1932160/32135239-2be40dd2-bbfc-11e7-89cb-2e7ede1b7d78.png)
