### PR TITLE
added the ability to set environment when running build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -82,7 +82,7 @@ measureFileSizesBeforeBuild(paths.appBuild)
 
 // Create the production build and print the deployment instructions.
 function build(previousFileSizes) {
-  console.log('Creating an optimized production build...');
+  console.log(`Creating an optimized ${process.env.NODE_ENV} build...`);
 
   const compiler = webpack(config);
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Default behaviour has not been changed, `NODE_ENV` is still production if not set.

Can verify with 
```
$ elm-app build # still uses .env.production
$ NODE_ENV=production elm-app build # uses .env.production
$ NODE_ENV=test elm-app build # uses .env.test
```

Fixes issiue #180 