### PR TITLE
Remove trailing spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,10 +8,10 @@
 
 <!--
   If you answered "Yes":
-  
+
     Please note that your issue will be fixed much faster if you spend about
     half an hour preparing it, including the exact reproduction steps and a demo.
-    
+
     If you're in a hurry or don't feel confident, it's fine to report bugs with
     less details, but this makes it less likely they'll get fixed soon.
 
@@ -30,10 +30,10 @@
   Please fill in all the relevant fields by running these commands in terminal.
 -->
 
-1. `node -v`: 
+1. `node -v`:
 2. `npm -v`:
 3. `yarn --version` (if you use Yarn):
-4. `npm ls create-elm-app -g` (if you haven’t ejected): 
+4. `npm ls create-elm-app -g` (if you haven’t ejected):
 
 Then, specify:
 
@@ -50,9 +50,9 @@ Then, specify:
 
 (Write your steps here:)
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 
 ### Expected Behavior
@@ -99,11 +99,11 @@ Then, specify:
 
 <!--
   What happens if you skip this step?
-  
+
   We will try to help you, but in many cases it is impossible because crucial
   information is missing. In that case we'll tag an issue as having a low priority,
   and eventually close it if there is no clear direction.
-  
+
   We still appreciate the report though, as eventually somebody else might
   create a reproducible example for it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,19 @@
 
 ### Upgrade from 0.17.1 to 0.18.0
 
-* Upgrade Elm to 0.18.0, read more in the official blog post [The Perfect Bug Report](http://elm-lang.org/blog/the-perfect-bug-report)  
+* Upgrade Elm to 0.18.0, read more in the official blog post [The Perfect Bug Report](http://elm-lang.org/blog/the-perfect-bug-report)
 ([@mikker](https://github.com/mikker) in [#54](https://github.com/halfzebra/create-elm-app/pull/54))
 
 ### Test setup refactoring
 
-* Better testing setup for the command line interface and functionality.  
+* Better testing setup for the command line interface and functionality.
  ([@fobos](https://github.com/fobos) in [#53](https://github.com/halfzebra/create-elm-app/pull/53))
 
 ## 0.1.10 (November 11, 2016)
 
 ### Command line improvements
 
-* Return exit code from spawned process in run scripts. CLI will now return correct exit codes.   
+* Return exit code from spawned process in run scripts. CLI will now return correct exit codes.
 ([@fobos](https://github.com/eanplatter) in [#46](https://github.com/halfzebra/create-elm-app/pull/46))
 * Add test case with returning non zero exit codes ([@fobos](https://github.com/eanplatter) in [#50](https://github.com/halfzebra/create-elm-app/pull/50))
 * Add getting started instructions to create script. ([@eanplatter](https://github.com/eanplatter) in [#51](https://github.com/halfzebra/create-elm-app/pull/51))

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ It bundles Elm app and optimizes the build for the best performance.
 The build is minified, and the filenames include the hashes.
 
 ## Guide
-Every generated project will contain a readme with guidelines for future development. 
+Every generated project will contain a readme with guidelines for future development.
 The latest version is available [here](https://github.com/halfzebra/create-elm-app/blob/master/template/README.md)
 
 ## Why use this?
 Developing with [elm-platform](https://github.com/elm-lang/elm-platform) is fun and easy, but at some point, you will hit a couple of limitations.
 
 - [elm-make](https://github.com/elm-lang/elm-make) does not provide an efficient build tool for optimizing your project.
-- [elm-reactor](https://github.com/elm-lang/elm-reactor) does not work with apps that rely on [ports.](http://guide.elm-lang.org/interop/javascript.html) 
+- [elm-reactor](https://github.com/elm-lang/elm-reactor) does not work with apps that rely on [ports.](http://guide.elm-lang.org/interop/javascript.html)
 - You can not use [Hot Module Replacement.](https://webpack.github.io/docs/hot-module-replacement.html)
 
 Create Elm App adds a tool for optimizing production builds and running a development server with your app, which supports HMR.

--- a/template/README.md
+++ b/template/README.md
@@ -1,6 +1,6 @@
 This project is bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app).
 
-Below you will find some information on how to perform basic tasks.  
+Below you will find some information on how to perform basic tasks.
 You can find the most recent version of this guide [here](https://github.com/halfzebra/create-elm-app/blob/master/template/README.md).
 
 ## Table of Contents
@@ -108,16 +108,16 @@ You may create subdirectories inside src.
 ## Available scripts
 In the project directory you can run:
 ### `elm-app build`
-Builds the app for production to the `build` folder.  
+Builds the app for production to the `build` folder.
 
-The build is minified, and the filenames include the hashes.  
+The build is minified, and the filenames include the hashes.
 Your app is ready to be deployed!
 
 ### `elm-app start`
-Runs the app in the development mode.  
+Runs the app in the development mode.
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-The page will reload if you make edits.  
+The page will reload if you make edits.
 You will also see any lint errors in the console.
 
 ### `elm-app install`
@@ -499,7 +499,7 @@ In Elm code, you can use `%PUBLIC_URL%` for similar purposes:
 
 ```elm
 // Note: this is an escape hatch and should be used sparingly!
-// Normally we recommend using `import`  and `Html.programWithFlags` for getting 
+// Normally we recommend using `import`  and `Html.programWithFlags` for getting
 // asset URLs as described in “Adding Images and Fonts” above this section.
 img [ src "%PUBLIC_URL%/logo.svg" ] []
 ```
@@ -594,7 +594,7 @@ To forward the API ( REST ) calls to backend server, add a proxy to the `elm-pac
 ```
 
 Make sure the XHR requests set the `Content-type: application/json` and `Accept: application/json`.
-The development server has heuristics, to handle its own flow, which may interfere with proxying of 
+The development server has heuristics, to handle its own flow, which may interfere with proxying of
 other html and javascript content types.
 
 ```sh
@@ -610,7 +610,7 @@ Create Elm App uses [elm-test](https://github.com/rtfeldman/node-test-runner) as
 To use packages in tests, you also need to install them in `tests` directory.
 
 ```bash
-elm-app test --add-dependencies elm-package.json 
+elm-app test --add-dependencies elm-package.json
 ```
 
 ### Continuous Integration

--- a/tests/fixtures/Main.elm
+++ b/tests/fixtures/Main.elm
@@ -5,5 +5,5 @@ import Html.App exposing (program)
 
 
 main : Program Never
-main 
+main
     program { view = view, init = init, update = update, subscriptions = subscriptions }


### PR DESCRIPTION
After using this (great!) tool, I opened the generated `README.md` to look at it and closed it. My editor automatically removes trailing spaces, so I was surprised to see changes in that file when I was `git add`-ing. 

I only intended to do this for `template/README.md`, since that's what's generated for people. I figured I might as well clean up the rest of the project too.

(For reference, I used: `find . -not \( -name .svn -prune -o -name .git -prune \) -type f -print0 | xargs -0 sed -i '' -E "s/[[:space:]]*$//"` combined with `export LANG=C` and `export LC_CTYPE=C` beforehand, on macOS High Sierra, which I got from StackOverflow. It also modified `template/public/favicon.ico` but I'm not comfortable altering that because I don't know the file format.)