### PR TITLE
config/webpackDevServer.config.js: Fix deprecation warning

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -78,7 +78,7 @@ module.exports = function(proxy, allowedHost) {
     },
     public: allowedHost,
     proxy,
-    setup(app) {
+    before(app) {
       // This lets us open files from the runtime error overlay.
       app.use(errorOverlayMiddleware());
       // This service worker file is effectively a 'no-op' that will reset any


### PR DESCRIPTION
`setup` was deprecated in webpack/webpack-dev-server#1108