### PR TITLE
Added an option to enable polyfill for Babel Transform Runtime plugin

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -99,7 +99,7 @@ module.exports = {
               require.resolve('babel-plugin-transform-runtime'),
               {
                 helpers: false,
-                polyfill: false,
+                polyfill: process.env.BABEL_TRANSFORM_RUNTIME_POLYFILL === 'true' ? true : false,
                 regenerator: true
               }
             ]

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -122,7 +122,7 @@ module.exports = {
               require.resolve('babel-plugin-transform-runtime'),
               {
                 helpers: false,
-                polyfill: false,
+                polyfill: process.env.BABEL_TRANSFORM_RUNTIME_POLYFILL === 'true' ? true : false,
                 regenerator: true
               }
             ]

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-#transform-runtime Elm App
+# Elm App
 
 This project is bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app).
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-# Elm App
+#transform-runtime Elm App
 
 This project is bootstrapped with [Create Elm App](https://github.com/halfzebra/create-elm-app).
 
@@ -49,6 +49,7 @@ You can find the most recent version of this guide [here](https://github.com/hal
   * [Static Server](#static-server)
   * [GitHub Pages](#github-pages)
 * [IDE setup for Hot Module Replacement](#ide-setup-for-hot-module-replacement)
+* [Babel Transform Runtime plugin options](#babel-transform-runtime-plugin-options)
 
 ## Sending feedback
 
@@ -850,3 +851,10 @@ GitHub Pages doesn’t support routers that use the HTML5 `pushState` history AP
 ## IDE setup for Hot Module Replacement
 
 Remember to disable [safe write](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write) if you are using VIM or IntelliJ IDE, such as WebStorm.
+
+## Babel Transform Runtime plugin options
+
+By default, Babel Transform Runtime plugin is configured to **not** transform new built-ins (Promise, Set, Map, etc.) to use a non-global polluting polyfill ([Babel Runtime transform plugin documentation](https://babeljs.io/docs/plugins/transform-runtime/)).
+
+To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true` or `false` respectively.
+

--- a/template/README.md
+++ b/template/README.md
@@ -856,5 +856,5 @@ Remember to disable [safe write](https://webpack.github.io/docs/webpack-dev-serv
 
 By default, Babel Transform Runtime plugin is configured to **not** transform new built-ins (Promise, Set, Map, etc.) to use a non-global polluting polyfill ([Babel Runtime transform plugin documentation](https://babeljs.io/docs/plugins/transform-runtime/)).
 
-To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true` or `false` respectively.
+To enable this transformation set `BABEL_TRANSFORM_RUNTIME_POLYFILL` environment variable to `true`.
 


### PR DESCRIPTION
Hi,

I've added an option with docs update to enable polyfill in [Babel Transform Runtime plugin](https://babeljs.io/docs/plugins/transform-runtime/). 

This option is recommended for libraries, while babel-polyfill is recommended for apps, but because I'm building an app that's embeddable on arbitrary websites, global polluting polyfill is not an option and so I cannot use babel-polyfill.