### PR TITLE
docs(template/README.md): Fix multi-line comment in Elm code block

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -566,9 +566,10 @@ When you run `elm-app build`, Create Elm App will substitute `%PUBLIC_URL%` with
 In Elm code, you can use `%PUBLIC_URL%` for similar purposes:
 
 ```elm
-// Note: this is an escape hatch and should be used sparingly!
-// Normally we recommend using `import`  and `Html.programWithFlags` for getting
-// asset URLs as described in “Adding Images and Fonts” above this section.
+{- Note: this is an escape hatch and should be used sparingly!
+   Normally we recommend using `import` and `Html.programWithFlags` for getting
+   asset URLs as described in “Adding Images and Fonts” above this section.
+-}
 img [ src "%PUBLIC_URL%/logo.svg" ] []
 ```
 


### PR DESCRIPTION
## Using the `public` Folder
### Adding Assets Outside of the Module System

```elm
// The comment looked
// a little strange.
```

#### Before
<img width="907" alt="screen shot 2018-07-25 at 12 57 33 am" src="https://user-images.githubusercontent.com/1707217/43180398-e3254876-8fa5-11e8-86ff-5b03f0949960.png">

#### After
<img width="909" alt="screen shot 2018-07-25 at 1 17 27 am" src="https://user-images.githubusercontent.com/1707217/43180909-970c3384-8fa8-11e8-8f2b-6aae17507990.png">


