### PR TITLE
fix: exclude build products under template from packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ repl-temp-*
 
 # create-elm-app
 template/build
+template/elm-stuff
+template/index.html
 template/package.json
 template/scripts/
 template/config/

--- a/package.json
+++ b/package.json
@@ -83,7 +83,13 @@
     "config",
     "scripts",
     "template",
-    "README.md"
+    "README.md",
+    "!template/build",
+    "!template/config/",
+    "!template/elm-stuff/",
+    "!template/index.html",
+    "!template/package.json",
+    "!template/scripts/"
   ],
   "keywords": [
     "cli",


### PR DESCRIPTION
`.gitignore` was ignoring some items under template that still appeared in the packaged releases,
because `template` was explicitly included in package.json, and that overrides those ignores.

Both the 2.0.0-rc1 and 2.0.0-rc2 releases included stray build products.

Adding explicit exclusions for the build products under `template` to `package.json` prevents
packaging errors.

I've added `template/elm-stuff` and `template/index.html` to `.gitignore` too, because those
are created if `elm make src/Main.elm` is run in `template`, which seems to have been the cause.

verified the changes by using `rm *.tgz; (cd template; elm make src/Main.elm); npm pack`, and inspecting the list of files packed.

re #275

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
