### PR TITLE
Making `create-elm-app` work also as a local dev dependency

### DIFF
--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -5,7 +5,10 @@
 const path = require('path');
 const spawn = require('cross-spawn');
 const argv = require('minimist')(process.argv.slice(2));
-const elmExecutable = path.resolve(__dirname, '../node_modules/.bin/elm');
+const elmExecutable = path.resolve(
+  path.dirname(require.resolve('elm')),
+  './bin/elm'
+);
 const version = require('../package.json').version;
 const elmVersion = require('elm/package.json').version;
 

--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -5,10 +5,7 @@
 const path = require('path');
 const spawn = require('cross-spawn');
 const argv = require('minimist')(process.argv.slice(2));
-const elmExecutable = path.resolve(
-  path.dirname(require.resolve('elm')),
-  './bin/elm'
-);
+const elmExecutable = require.resolve('elm/bin/elm');
 const version = require('../package.json').version;
 const elmVersion = require('elm/package.json').version;
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -47,7 +47,7 @@ module.exports = {
   entry: resolveApp('./src/index.js'),
   appBuild: resolveApp('./build'),
   elmJson: resolveApp('./elm.json'),
-  elm: path.resolve(path.dirname(require.resolve('elm')), './bin/elm'),
+  elm: require.resolve('elm/bin/elm'),
   publicUrl: getPublicUrl(resolveApp('elm.json')),
   servedPath: getServedPath(resolveApp('elm.json'))
 };

--- a/config/paths.js
+++ b/config/paths.js
@@ -47,7 +47,7 @@ module.exports = {
   entry: resolveApp('./src/index.js'),
   appBuild: resolveApp('./build'),
   elmJson: resolveApp('./elm.json'),
-  elm: path.resolve(__dirname, '../node_modules/.bin/elm'),
+  elm: path.resolve(path.dirname(require.resolve('elm')), './bin/elm'),
   publicUrl: getPublicUrl(resolveApp('elm.json')),
   servedPath: getServedPath(resolveApp('elm.json'))
 };


### PR DESCRIPTION
Fixing #289 

Updating how to get the path for `elm` command so that it works also as a local dev dependency.