### PR TITLE
Make minified code compatible with IE11

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -83,7 +83,9 @@ module.exports = {
     minimizer: [
       new UglifyJsPlugin({
         uglifyOptions: {
-          ecma: 8,
+          // ES5 is required in the minified code if you want compatibility with IE11,
+          // otherwise you can bump it up to ES8
+          ecma: 5,
           compress: Object.assign(
             {},
             {


### PR DESCRIPTION
Hi!
First of all, thank you for this project. It has a great set of features and for that reason it is the starting point for my current app.
Regarding browser compatibility, I spent a few hours trying to figure out why the code would work in Internet Explorer 11 (IE11) in development but not in production mode.

## TLDR

ES5 is required in the minified code if you want compatibility with IE11.

## Explanation

![image](https://user-images.githubusercontent.com/3451581/46106427-04df9800-c1af-11e8-9ff2-d0b227df6e36.png)

![ie screenshot](https://user-images.githubusercontent.com/3451581/46106621-9818cd80-c1af-11e8-9ca0-1ee1280753f8.png)

As it turns out, even though Babel makes ES5 code, you need to make UglifyJS export ES5 code as well after minification, otherwise an object like `{$:3,n:n,p:r}` gets abbreviated to `{$:3,n,p:r}` using [ES6 object-shorthand syntax](https://eslint.org/docs/rules/object-shorthand).

