### PR TITLE
Uglifyjs configuration for elm 0.19

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -24,34 +24,7 @@ const publicUrl = publicPath.slice(0, -1);
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
-const useDebugger = process.env.ELM_DEBUGGER === 'true' ? true : false;
-
-// Enable users to turn on dead code elimination.
-const deadCodeElimination =
-  process.env.DEAD_CODE_ELIMINATION === 'true'
-    ? {
-        dead_code: true,
-        pure_funcs: [
-          '_elm_lang$core$Native_Utils.update',
-          'A2',
-          'A3',
-          'A4',
-          'A5',
-          'A6',
-          'A7',
-          'A8',
-          'A9',
-          'F2',
-          'F3',
-          'F4',
-          'F5',
-          'F6',
-          'F7',
-          'F8',
-          'F9'
-        ]
-      }
-    : {};
+const useDebugger = process.env.ELM_DEBUGGER === 'true';
 
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
@@ -86,18 +59,38 @@ module.exports = {
           // ES5 is required in the minified code if you want compatibility with IE11,
           // otherwise you can bump it up to ES8
           ecma: 5,
-          compress: Object.assign(
-            {},
-            {
-              warnings: false,
-              // Disabled because of an issue with Uglify breaking seemingly valid code:
-              // https://github.com/facebook/create-react-app/issues/2376
-              // Pending further investigation:
-              // https://github.com/mishoo/UglifyJS2/issues/2011
-              comparisons: false
-            },
-            deadCodeElimination
-          ),
+          // Compression settings mostly based on <https://guide.elm-lang.org/optimization/asset_size.html>
+          compress: {
+            passes: 2,
+            warnings: false,
+            // Disabled because of an issue with Uglify breaking seemingly valid code:
+            // https://github.com/facebook/create-react-app/issues/2376
+            // Pending further investigation:
+            // https://github.com/mishoo/UglifyJS2/issues/2011
+            comparisons: false,
+            pure_getters: true,
+            keep_fargs: false,
+            unsafe_comps: true,
+            unsafe: true,
+            pure_funcs: [
+              'A2',
+              'A3',
+              'A4',
+              'A5',
+              'A6',
+              'A7',
+              'A8',
+              'A9',
+              'F2',
+              'F3',
+              'F4',
+              'F5',
+              'F6',
+              'F7',
+              'F8',
+              'F9'
+            ]
+          },
           mangle: {
             safari10: true
           },
@@ -129,7 +122,6 @@ module.exports = {
     modules: ['node_modules'],
     extensions: ['.js', '.elm']
   },
-
   module: {
     strictExportPresence: true,
 
@@ -212,7 +204,7 @@ module.exports = {
             }
           },
           {
-            // Use the local installation of elm-make
+            // Use the local installation of elm make
             loader: require.resolve('elm-webpack-loader'),
             options: {
               // If ELM_DEBUGGER was set to "true", enable it. Otherwise

--- a/template/README.md
+++ b/template/README.md
@@ -183,9 +183,7 @@ To turn on/off Elm Debugger explicitly, set `ELM_DEBUGGER` environment variable 
 
 ## Dead code elimination
 
-Create Elm App comes with an opinionated setup for dead code elimination which is disabled by default, because it may break your code.
-
-You can enable it by setting `DEAD_CODE_ELIMINATION` environment variable to `true`
+Create Elm App comes with an setup for dead code elimination which relies on the elm compiler flag `--optimize` and `uglifyjs`.
 
 ## Changing the base path of the assets in the HTML
 

--- a/tests/create-elm-app.spec.js
+++ b/tests/create-elm-app.spec.js
@@ -21,11 +21,7 @@ describe('Create Elm application with `create-elm-app` command', () => {
   }).timeout(60 * 1000);
 
   it(`'${testAppName}' should have elm.json file`, () => {
-    expect(
-      fs.existsSync(path.join(testAppDir, 'elm.json')),
-      'to be',
-      true
-    );
+    expect(fs.existsSync(path.join(testAppDir, 'elm.json')), 'to be', true);
   });
 
   it(`'${testAppName}' should have .gitignore file`, () => {


### PR DESCRIPTION
### Description

This PR addressed the changed discussed in #314. There might be still room in terms of shaving some bytes off, but this looks fine so far. I basically did comparisons to make sure we're not moving in the wrong direction.

```shell
# UglifyJsPlugin with settings of this PR
17.280 as  1 Nov 21:50 main.516c338b.chunk.js

# Unminified results (by disabling UglifyJsPlugin)
110.583 as  1 Nov 21:54 main.516c338b.chunk.js 

# elm-minify executed on unminified results
17.289 as  1 Nov 21:55 main.516c338b.chunk.min.js

# master without DEAD_CODE_ELIMINATION
29.660 as  1 Nov 22:20 main.9e0ba63c.chunk.js

# master with DEAD_CODE_ELIMINATION
17.876 as  1 Nov 22:21 main.9e0ba63c.chunk.js
```

### Changes
* Removes `DEAD_CODE_ELIMINATION` env
* Changed chapter in docs
* Sourcemaps disabled by default in prod build
* Uglify settings
  * Based on elm docs
  * 2 Passes

#### Testing
* Build application and executed it
* Ran `npm run test`

Solves #314 