### PR TITLE
Runtime opts to improve build speed 

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -176,6 +176,7 @@ module.exports = {
               // for invalid values, "true" and as a default, enable it
               debug: process.env.ELM_DEBUGGER === 'false' ? false : true,
               pathToElm: paths.elm,
+              runtimeOptions: '-A128M -H128M -n8m',
               forceWatch: true
             }
           }

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -211,7 +211,8 @@ module.exports = {
               // for invalid values, "false" and as a default, disable it
               debug: useDebugger,
               optimize: !useDebugger,
-              pathToElm: paths.elm
+              pathToElm: paths.elm,
+              runtimeOptions: '-A128M -H128M -n8m'
             }
           }
         ]


### PR DESCRIPTION
The pull requests adds the runtime opts. With tests I couldn't see a difference.
I tried to benchmark the changes on an application, but I don't know a large codebase with `create-elm-app`. The applications I have are fast, and with webpack and uglify and other parts of the build, I can't tell a difference with and without the arguments. So either there is no noticeable difference, they're not configured correctly or the difference will show with a larger codebase.

Ran the total optimized build a 100 times and got 7.7 minutes before, and 7.5 minutes with the changes. Could be measurement errors.

Is it possible to release it as `beta`/`next`/`rc` to try it on real world projects?
I wouldn't add the configuration if there the difference is not proven.

Potentially solves #321