### PR TITLE
Passing rts options argument as array

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -176,7 +176,7 @@ module.exports = {
               // for invalid values, "true" and as a default, enable it
               debug: process.env.ELM_DEBUGGER === 'false' ? false : true,
               pathToElm: paths.elm,
-              runtimeOptions: '-A128M -H128M -n8m',
+              runtimeOptions: ['-A128M', '-H128M', '-n8m'],
               forceWatch: true
             }
           }

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -212,7 +212,7 @@ module.exports = {
               debug: useDebugger,
               optimize: !useDebugger,
               pathToElm: paths.elm,
-              runtimeOptions: '-A128M -H128M -n8m'
+              runtimeOptions: ['-A128M', '-H128M', '-n8m']
             }
           }
         ]


### PR DESCRIPTION
The feature to pass compiler flags is hardly documented. A test of
`node-elm-compiler` is passing the argument in form of an array. Hence
the change from string to string array.

<https://github.com/rtfeldman/node-elm-compiler/blob/48f29fc243e149ad6f8ee0c6ef740d998764cf55/test/compile.js#L57>

Added a change to `elm-webpack-loader`, too.
https://github.com/elm-community/elm-webpack-loader/pull/161