### PR TITLE
Bump latest versions of elm core

### DIFF
--- a/template/elm.json
+++ b/template/elm.json
@@ -4,15 +4,15 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
             "elm/html": "1.0.0"
         },
         "indirect": {
-            "elm/json": "1.0.0",
+            "elm/json": "1.1.2",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
This allows latest elm/http to be picked up by app initialised with create-elm-app command.

This is simplest solution to this problem, unfortunately at some point elm.json will become outdated again. So being a good enough as a hotfix, it doesn't address underlying issue, which could be solved in a better way if, for example `elm init` would be run as part of create-elm-app initialisation procedure.

Closes #333