### PR TITLE
Add —no-debug Option To Disable Elm Debugger

### DIFF
--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -29,13 +29,18 @@ if (commands.length === 0) {
 
 const script = commands[0];
 const scriptArgs = commands.splice(1);
+const { _, ...options } = argv;
 
 switch (script) {
   case 'create':
   case 'build':
   case 'eject':
   case 'start':
-    spawnSyncNode(path.resolve(__dirname, '../scripts', script), scriptArgs);
+    spawnSyncNode(
+      path.resolve(__dirname, '../scripts', script),
+      scriptArgs,
+      options
+    );
     break;
 
   case 'test': {
@@ -100,9 +105,13 @@ function help(version) {
  * @return {undefined}
  */
 function spawnSyncNode(script, args) {
-  const cp = spawn.sync('node', [script].concat(args || []), {
-    stdio: 'inherit'
-  });
+  const cp = spawn.sync(
+    'node',
+    [script].concat(args || []).concat(JSON.stringify(options)),
+    {
+      stdio: 'inherit'
+    }
+  );
 
   if (cp.status !== 0) {
     process.exit(cp.status);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -4,6 +4,10 @@
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';
 
+const options = JSON.parse(process.argv[process.argv.length - 1]);
+
+process.env.ELM_DEBUGGER = options.debug !== false;
+
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.


### PR DESCRIPTION
On the elm-slack, a number of times people have asked how to turn off the elm debugger when running `elm-app start`, either for performance reasons, or for other reasons. This PR add a —no-debug option that will disable the elm debugger.