### PR TITLE
fix: strip compilation progress bar on Windows

### DIFF
--- a/scripts/utils/formatElmCompilerErrors.js
+++ b/scripts/utils/formatElmCompilerErrors.js
@@ -18,7 +18,7 @@ function stripRedundantInfo(error) {
       // String the error message from the loader.
       .replace(/Module build failed.*\nError.*\n/gm, '')
       // Strip compilation progress-bar.
-      .replace(/\[=+\]\s-\s\d\s\/\s\d[\r\n\s]?/gm, '\n')
+      .replace(/\[[=\s]{3,}\]\s-\s\d+\s\/\s\d+[\r\n\s]+/gm, '')
   );
 }
 
@@ -34,7 +34,9 @@ module.exports = function formatElmCompilerErrors(messages) {
               .replace(/(\n\s*)(\^+)/g, '$1' + error('$2'))
               .replace(/(\d+)(\|>)/g, '$1' + error('$2'))
           )
-          .map(stripRedundantInfo),
+          .map(stripRedundantInfo)
+          // drop errors that only contain whitespace
+          .filter(err => err.trim()),
         warnings: warnings
       }
     : messages;


### PR DESCRIPTION
Hello,

I'm not sure if this only happens on Windows 10, but the error overlay in the browser on compilation failure looks e.g. like this
```
Error: Compiler process exited with error Compilation failed
[                                                  ] - 1 / 74
[=                                                 ] - 2 / 74
[==                                                ] - 3 / 74
[==                                                ] - 4 / 74
[===                                               ] - 5 / 74
[====                                              ] - 6 / 74
...
[===============================================   ] - 70 / 74
[===============================================   ] - 71 / 74
```
Which is why I changed the rule on line 21 to match not only
`[================================================] - 7 / 7`
But also the following lines
```
[================================================] - 17 / 17
[                                                  ] - 1 / 74
[===============================================   ] - 71 / 74
```


Regards,
marc