### PR TITLE
Ignore scss and sass files for url-loader

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -219,7 +219,7 @@ module.exports = {
       },
 
       {
-        exclude: [/\.html$/, /\.js$/, /\.elm$/, /\.css$/, /\.json$/, /\.svg$/],
+        exclude: [/\.html$/, /\.js$/, /\.elm$/, /\.css$/, /\.scss$/, /\.sass$/, /\.json$/, /\.svg$/],
         loader: require.resolve('url-loader'),
         options: {
           limit: 10000,

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -253,7 +253,7 @@ module.exports = {
       },
 
       {
-        exclude: [/\.html$/, /\.js$/, /\.elm$/, /\.css$/, /\.json$/, /\.svg$/],
+        exclude: [/\.html$/, /\.js$/, /\.elm$/, /\.css$/, /\.scss$/, /\.sass$/, /\.json$/, /\.svg$/],
         loader: require.resolve('url-loader'),
         options: {
           limit: 10000,


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Adding a scss or sass handler conflicts with the URL-loader, which produces a weird error message. Ignoring scss and sass files in the first place allows adding a scss loader without ejecting the web pack config (and then applying the fix in this pull request). 

Best, 
ambiso