### PR TITLE
Fix webpack safe-write link in guide

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -925,4 +925,4 @@ GitHub Pages doesn’t support routers that use the HTML5 `pushState` history AP
 
 ## IDE setup for Hot Module Replacement
 
-Remember to disable [safe write](https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write) if you are using VIM or IntelliJ IDE, such as WebStorm.
+Remember to disable [safe write](https://webpack.js.org/guides/development/#adjusting-your-text-editor) if you are using VIM or IntelliJ IDE, such as WebStorm.


### PR DESCRIPTION
Fix removed webpack documentation:

![image](https://user-images.githubusercontent.com/13085980/57985839-21964c00-7a6e-11e9-8782-50c5fd6aee26.png)
