### PR TITLE
feat: Add `--no-browser` flag to `start` command

### DIFF
--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -28,14 +28,29 @@ if (commands.length === 0) {
 }
 
 const script = commands[0];
-const scriptArgs = commands.splice(1);
 
 switch (script) {
   case 'create':
   case 'build':
   case 'eject':
   case 'start':
-    spawnSyncNode(path.resolve(__dirname, '../scripts', script), scriptArgs);
+    if (argv['help']) {
+      help(version, 'start');
+      break;
+    }
+
+    let args = [];
+    Object.keys(argv || {}).forEach(key => {
+      if (key === 'browser') {
+        // `--no-browser` turns into `--browser false`
+        // See https://github.com/substack/minimist/issues/123
+        args = args.concat([
+          argv[key] ? '--browser' : '--no-browser'
+        ]);
+      }
+    });
+
+    spawnSyncNode(path.resolve(__dirname, '../scripts', script), args);
     break;
 
   case 'test': {
@@ -76,19 +91,35 @@ switch (script) {
 /**
  *Prints help message
  *
- * @param  {string} version [description]
+ * @param  {string} version Package version
+ * @param  {string} command Name of command for which to print help message
  * @return {undefined}
  */
-function help(version) {
-  console.log();
-  console.log('Usage: elm-app <command>');
-  console.log();
-  console.log('where <command> is one of:');
-  console.log('    build, start, test, eject, ' + elmCommands.join(', '));
-  console.log();
-  console.log();
-  console.log('Elm ' + elmVersion);
-  console.log();
+function help(version, command='') {
+  switch (command) {
+    case 'start':
+      console.log();
+      console.log('Usage: elm-app start [options...]');
+      console.log();
+      console.log('where [options...] is any number of:');
+      console.log('--no-browser\tDo not open the browser automatically');
+      console.log();
+      break;
+    case 'test':
+      // NOTE: Current implementation calls through to `elm-test` for help message
+      break;
+    default:
+      console.log();
+      console.log('Usage: elm-app <command>');
+      console.log();
+      console.log('where <command> is one of:');
+      console.log('    build, start, test, eject, ' + elmCommands.join(', '));
+      console.log();
+      console.log();
+      console.log('Elm ' + elmVersion);
+      console.log();
+  }
+
   console.log(
     'create-elm-app@' + version + ' ' + path.resolve(__dirname, '..')
   );

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -33,6 +33,8 @@ const formatElmCompilerErrors = require('./utils/formatElmCompilerErrors');
 const paths = require('../config/paths');
 const warn = require('./utils/warn');
 
+const openBrowserFlag = !process.argv.includes('--no-browser');
+
 if (fs.existsSync('elm.json') === false) {
   console.log('Please, run the build script from project root directory');
   process.exit(0);
@@ -183,7 +185,9 @@ choosePort(HOST, DEFAULT_PORT)
         clearConsole();
       }
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
+      if (openBrowserFlag) {
+        openBrowser(urls.localUrlForBrowser);
+      }
     });
 
     ['SIGINT', 'SIGTERM'].forEach(sig => {

--- a/template/README.md
+++ b/template/README.md
@@ -128,12 +128,18 @@ Your app is ready to be deployed!
 ### `elm-app start`
 
 Runs the app in the development mode.
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The browser should open automatically to [http://localhost:3000](http://localhost:3000). If the browser does no open, you can open it manually and visit the URL.
 
 The page will reload if you make edits.
 You will also see any lint errors in the console.
 
 You may change the listening port number by using the `PORT` environment variable. For example type `PORT=8000 elm-app start ` into the terminal/bash to run it from: [http://localhost:8000/](http://localhost:8000/).
+
+You can prevent the browser from opening automatically,
+```sh
+elm-app start --no-browser
+```
 
 ### `elm-app install`
 

--- a/template/README.md
+++ b/template/README.md
@@ -129,7 +129,7 @@ Your app is ready to be deployed!
 
 Runs the app in the development mode.
 
-The browser should open automatically to [http://localhost:3000](http://localhost:3000). If the browser does no open, you can open it manually and visit the URL.
+The browser should open automatically to [http://localhost:3000](http://localhost:3000). If the browser does not open, you can open it manually and visit the URL.
 
 The page will reload if you make edits.
 You will also see any lint errors in the console.


### PR DESCRIPTION
- No default behavior has changed
- An optional `--no-browser` flag has been added to the `start` command that prevents opening the browser automatically
- An optional `--help` flag has been added to the `start` command which displays help for the `start` command
- The `help` function in `elm-app-cli.js` has been refactored to be able to provide additional help messages for other commands
