### PR TITLE
Also resolve mjs modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 node_js:
-  - '12'
+  - '11'
   - '8'
 addons:
   apt:

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -125,7 +125,7 @@ module.exports = {
       // Process any JS outside of the app with Babel.
       // Unlike the application JS, we only compile the standard ES features.
       {
-        test: /\.js$/,
+        test: /\.m?js$/,
         use: [
           {
             loader: require.resolve('babel-loader'),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -164,7 +164,7 @@ module.exports = {
       // Process any JS outside of the app with Babel.
       // Unlike the application JS, we only compile the standard ES features.
       {
-        test: /\.js$/,
+        test: /\.m?js$/,
         use: [
           {
             loader: require.resolve('babel-loader'),


### PR DESCRIPTION
Hello ! I was having trouble importing a module that depended on another mjs module.

I corrected this by `elm-app eject` and making those two changes.

Maybe we could add them back to the main repo and share with everyone !

It would also make me able to revert my `eject` and use the create-elm-app as is again.