### PR TITLE
Update insecure dependencies

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -231,7 +231,6 @@ module.exports = {
             loader: require.resolve('css-loader'),
             options: {
               importLoaders: 1,
-              minimize: true,
               sourceMap: shouldUseSourceMap
             }
           },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -11,6 +11,8 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const paths = require('../config/paths');
 const getClientEnvironment = require('./env');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const safePostCssParser = require('postcss-safe-parser');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -107,6 +109,20 @@ module.exports = {
         // Enable file caching
         cache: true,
         sourceMap: shouldUseSourceMap
+      }),
+      new OptimizeCSSAssetsPlugin({
+        cssProcesorOptions: {
+          parser: safePostCssParser,
+          map: shouldUseSourceMap
+            ? {
+                // This forces the sourcemap to be output into a separate file
+                inline: false,
+                // This appends the sourceMappingURL to the end of the css file,
+                // helping the browser find the sourcemap
+                annotation: true
+              }
+            : false
+        }
       })
     ],
     // Automatically split vendor and commons

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-flexbugs-fixes": "^3.3.0",
     "postcss-loader": "2.1.5",
+    "postcss-safe-parser": "^4.0.1",
     "promise": "8.0.1",
     "prompt": "1.0.0",
     "react-dev-utils": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "connect-history-api-fallback": "^1.5.0",
     "cosmiconfig": "^5.0.6",
     "cross-spawn": "^6.0.5",
-    "css-loader": "^0.28.9",
+    "css-loader": "^3.2.0",
     "dotenv": "^5.0.0",
     "elm": "0.19.0-bugfix6",
     "elm-hot-webpack-loader": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "http-proxy-middleware": "^0.20.0",
     "mini-css-extract-plugin": "^0.4.0",
     "minimist": "1.2.0",
+    "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-flexbugs-fixes": "^3.3.0",
     "postcss-loader": "2.1.5",
     "promise": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "file-loader": "^1.1.6",
     "fs-extra": "^6.0.1",
     "html-webpack-plugin": "^4.0.0-alpha.2",
-    "http-proxy-middleware": "^0.17.4",
+    "http-proxy-middleware": "^0.20.0",
     "mini-css-extract-plugin": "^0.4.0",
     "minimist": "1.2.0",
     "postcss-flexbugs-fixes": "^3.3.0",


### PR DESCRIPTION
I ran `npm audit` on the current master, and got the following output:

```
create-elm-app$ npm i && npm i --package-lock-only && npm audit

[...]

added 274 packages from 176 contributors, removed 22 packages, updated 13 packages and audited 33377 packages in 23.756s
found 9 vulnerabilities (1 low, 1 moderate, 7 high)
  run `npm audit fix` to fix them, or `npm audit` for details
npm WARN deprecated fsevents@1.2.4: Way too old
npm notice created a lockfile as package-lock.json. You should commit this file.
added 67 packages from 25 contributors and audited 33377 packages in 11.444s
found 9 vulnerabilities (1 low, 1 moderate, 7 high)
  run `npm audit fix` to fix them, or `npm audit` for details
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm install http-proxy-middleware@0.20.0  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ braces                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ http-proxy-middleware                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ http-proxy-middleware > micromatch > braces                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/786                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm install css-loader@3.2.0  to resolve 2 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ js-yaml                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ css-loader                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ css-loader > cssnano > postcss-svgo > svgo > js-yaml         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/788                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Code Injection                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ js-yaml                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ css-loader                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ css-loader > cssnano > postcss-svgo > svgo > js-yaml         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/813                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Arbitrary File Overwrite                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ tar                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.2.2 <3.0.0 || >=4.4.2                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ elm-test                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ elm-test > fsevents > node-pre-gyp > tar                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/803                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.12                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ elm-test                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ elm-test > lodash                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.12                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ elm-test                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ elm-test > node-elm-compiler > find-elm-dependencies >       │
│               │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.12                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ 1fb45c857a90c84bab03ccb5bed8abdd0003ac7a7f40c9e8b14bb021ad0… │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ 1fb45c857a90c84bab03ccb5bed8abdd0003ac7a7f40c9e8b14bb021ad0… │
│               │ > node-elm-compiler > find-elm-dependencies > lodash         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.12                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ elm-test                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ elm-test > node-elm-compiler > lodash                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.12                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ 1fb45c857a90c84bab03ccb5bed8abdd0003ac7a7f40c9e8b14bb021ad0… │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ 1fb45c857a90c84bab03ccb5bed8abdd0003ac7a7f40c9e8b14bb021ad0… │
│               │ > node-elm-compiler > lodash                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 9 vulnerabilities (1 low, 1 moderate, 7 high) in 33377 scanned packages
  run `npm audit fix` to fix 1 of them.
  2 vulnerabilities require semver-major dependency updates.
  6 vulnerabilities require manual review. See the full report for details.
```

As you can see, there are some quite severe vulnerabilities present here, including denial of service, arbitrary code execution and arbitrary file overwrites.

This PR fixes the denial of service vulnerabilities and the arbitrary code execution vulnerability. It does not fix the vulnerabilities present in `elm-test`, as no update is currently available. However https://github.com/rtfeldman/node-test-runner/issues/360 suggests that a new release which fixes all these vulnerabilities is just around the corner.

The update of `http-proxy-middleware` from `0.17.4` to `0.20.0` was unproblematic.

The update of `css-loader` from `0.28.9` to `3.2.0` was slightly more problematic. Specifically, the `minimize` option was removed in [css-loader release 1.0.0](https://github.com/webpack-contrib/css-loader/releases/tag/v1.0.0); quoth the release notes:

>remove minimize option, use postcss-loader with cssnano or use optimize-cssnano-plugin plugin

I am not quite comfortable with webpack configs yet, so I have not done this change. Presumably, this currently means that running `npm build` on an ejected project (and perhaps also on non-ejected projects?) will no longer minimize css.

I am sure re-adding this functionality will be both easy and quick for someone who is more experienced with webpack than I am, and so I would appreciate pointers or help with doing so.