### PR TITLE
refactor(package.json): elm-webpack-loader 6.0.0 instead of fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "elm": "0.19.0-bugfix6",
     "elm-hot-webpack-loader": "^1.0.2",
     "elm-test": "^0.19.0-rev5",
-    "elm-webpack-loader": "github:halfzebra/elm-webpack-loader#updated-elm-compiler",
+    "elm-webpack-loader": "6.0.0",
     "file-loader": "^1.1.6",
     "fs-extra": "^6.0.1",
     "html-webpack-plugin": "^4.0.0-alpha.2",


### PR DESCRIPTION
If there is no reason against it that I'm not aware of, this can be merged back to use the base repository of `elm-webpack-loader`.

fix #373
