### PR TITLE
feat(webpack config): elm-webpack-asset-loader to require assets

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -83,7 +83,6 @@ module.exports = {
     extensions: ['.js', '.elm']
   },
   module: {
-    noParse: /\.elm$/,
     strictExportPresence: true,
     rules: [
       // Disable require.ensure as it's not a standard language feature.
@@ -167,6 +166,9 @@ module.exports = {
               replace: publicUrl,
               flags: 'g'
             }
+          },
+          {
+            loader: require.resolve('elm-asset-webpack-loader')
           },
           {
             loader: require.resolve('elm-webpack-loader'),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -142,8 +142,6 @@ module.exports = {
   module: {
     strictExportPresence: true,
 
-    noParse: /\.elm$/,
-
     rules: [
       {
         test: /\.js$/,
@@ -219,6 +217,9 @@ module.exports = {
               replace: publicUrl,
               flags: 'g'
             }
+          },
+          {
+            loader: require.resolve('elm-asset-webpack-loader')
           },
           {
             // Use the local installation of elm make
@@ -339,16 +340,14 @@ module.exports = {
       publicPath: publicPath
     }),
     // Copies the public folder to the build folder
-    new CopyPlugin([
-      { from: './public/', to: './' },
-    ]),
+    new CopyPlugin([{ from: './public/', to: './' }]),
     // Generate a service worker script that will precache, and keep up to date,
     // the HTML & assets that are part of the Webpack build.
     new workboxPlugin.GenerateSW({
-      swDest: "./service-worker.js",
+      swDest: './service-worker.js',
       skipWaiting: true,
       clientsClaim: true
-    }),
+    })
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cross-env": "^5.2.0",
     "cz-conventional-changelog": "^3.0.2",
     "dir-compare": "^1.4.0",
+    "elm-asset-webpack-loader": "1.1.1",
     "eslint": "^6.1.0",
     "eslint-plugin-prettier": "^3.1.0",
     "husky": "^3.0.3",


### PR DESCRIPTION
Resolves paths to assets in strings in Elm code with webpack.

Example:

```
img [ src "require:src/assets/logo.svg" ] []
```

Fixes #363

Documentation not part of this PR.
