### PR TITLE
fix(package.json): bumped elm-hot-webpack-loader to v1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "css-loader": "^3.2.0",
     "dotenv": "^5.0.0",
     "elm": "latest-0.19.1",
-    "elm-hot-webpack-loader": "^1.0.2",
+    "elm-hot-webpack-loader": "^1.1.5",
     "elm-test": "latest-0.19.1",
     "elm-webpack-loader": "6.0.0",
     "file-loader": "^1.1.6",


### PR DESCRIPTION
Bumped elm-hot-webpack-loader to v1.1.5 to address "Cannot read property \'hasOwnProperty\' of
undefined" error w/ elm/browser 1.0.2
