### PR TITLE
Update elm-asset-webpack-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "css-loader": "^3.2.0",
     "dotenv": "^5.0.0",
     "elm": "latest-0.19.1",
-    "elm-asset-webpack-loader": "1.1.1",
+    "elm-asset-webpack-loader": "^1.1.1",
     "elm-hot-webpack-loader": "^1.1.5",
     "elm-test": "latest-0.19.1",
     "elm-webpack-loader": "6.0.0",


### PR DESCRIPTION
Change updates a transitive dependency for security reasons recommended by github

Going with `^` for conistency with other versions