### PR TITLE
Fixed failed import of .mjs files

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -80,7 +80,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
-    extensions: ['.js', '.elm'],
+    extensions: ['.js', '.mjs', '.elm'],
   },
   module: {
     strictExportPresence: true,
@@ -93,7 +93,7 @@ module.exports = {
         exclude: [/[/\\\\]elm-stuff[/\\\\]/, /[/\\\\]node_modules[/\\\\]/],
         include: paths.appSrc,
         loader: require.resolve('babel-loader'),
-        query: {
+        options: {
           presets: [
             [
               require.resolve('@babel/preset-env'),
@@ -227,6 +227,7 @@ module.exports = {
         exclude: [
           /\.html$/,
           /\.js$/,
+          /\.mjs$/,
           /\.elm$/,
           /\.css$/,
           /\.scss$/,

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -139,7 +139,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
-    extensions: ['.js', '.elm'],
+    extensions: ['.js', '.mjs', '.elm'],
   },
   module: {
     strictExportPresence: true,
@@ -149,7 +149,7 @@ module.exports = {
         test: /\.js$/,
         exclude: [/[/\\\\]elm-stuff[/\\\\]/, /[/\\\\]node_modules[/\\\\]/],
         loader: require.resolve('babel-loader'),
-        query: {
+        options: {
           // Latest stable ECMAScript features
           presets: [
             [
@@ -278,6 +278,7 @@ module.exports = {
         exclude: [
           /\.html$/,
           /\.js$/,
+          /\.mjs$/,
           /\.elm$/,
           /\.css$/,
           /\.scss$/,


### PR DESCRIPTION
This should fix  #438 

It happened that weback select for .mjs url-loader instead of babel-loader.
I have also updated the syntax for the webpack configuration that switched from `query` to `options`